### PR TITLE
Fix a crash that would occur if an invalid token was provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,8 +49,11 @@ func main() {
 		fmt.Println(err.Error())
 		return
 	}
+
 	tempCreds := getSTSCredentials(sess, mfa, duration, user)
-	writeNewProfile(credFile, targetProfile, sourceProfile, tempCreds)
+	if tempCreds != nil {
+		writeNewProfile(credFile, targetProfile, sourceProfile, tempCreds)
+	}
 }
 
 func getMFACode() (string, error) {


### PR DESCRIPTION
If the token provided was rejected by STS, there would be a panic trying to dereference a nil pointer.