### PR TITLE
Fix panic if you don't have a region set in the source profile

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,7 +137,11 @@ func writeNewProfile(credFile *string, profileName *string, sourceProfile *strin
 	if err != nil {
 		section = config.NewSection(*profileName)
 	}
-	section.Add("region", region)
+
+	if region != "" {
+		section.Add("region", region)
+	}
+
 	section.Add("aws_access_key_id", *sessionDetails.Credentials.AccessKeyId)
 	section.Add("aws_secret_access_key", *sessionDetails.Credentials.SecretAccessKey)
 	section.Add("aws_session_token", *sessionDetails.Credentials.SessionToken)


### PR DESCRIPTION
If you don't have a region in your source profile, it would write a malformed target profile that would cause a panic on subsequent runs.